### PR TITLE
Add explicit annotation when using strict mode

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -1,9 +1,9 @@
 angular.module('gavruk.card', [])
 
-.controller('CardCtrl', function($scope) {
-})
+.controller('CardCtrl', ['$scope', function($scope) {
+}])
 
-.directive('card', function ($compile) {
+.directive('card', ['$compile', function ($compile) {
   return {
     restrict: 'A',
     scope: {
@@ -78,9 +78,9 @@ angular.module('gavruk.card', [])
       $(element).card(opts);
     }
   };
-})
+}])
 
-.directive('cardNumber', function($compile) {
+.directive('cardNumber', ['$compile', function($compile) {
   return {
     restrict: 'A',
     scope: {
@@ -97,16 +97,16 @@ angular.module('gavruk.card', [])
         if (oldVal === newVal && !newVal) {
           return;
         }
-        
+
         var evt = document.createEvent('HTMLEvents');
         evt.initEvent('keyup', false, true);
         element[0].dispatchEvent(evt);
       });
     }
   };
-})
+}])
 
-.directive('cardName', function($compile) {
+.directive('cardName', ['$compile', function($compile) {
   return {
     restrict: 'A',
     scope: {
@@ -130,9 +130,9 @@ angular.module('gavruk.card', [])
       });
     }
   };
-})
+}])
 
-.directive('cardExpiry', function($compile) {
+.directive('cardExpiry', ['$compile', function($compile) {
   return {
     restrict: 'A',
     scope: {
@@ -149,16 +149,16 @@ angular.module('gavruk.card', [])
         if (oldVal === newVal && !newVal) {
           return;
         }
-        
+
         var evt = document.createEvent('HTMLEvents');
         evt.initEvent('keyup', false, true);
         element[0].dispatchEvent(evt);
       });
     }
   };
-})
+}])
 
-.directive('cardCvc', function($compile) {
+.directive('cardCvc', ['$compile', function($compile) {
   return {
     restrict: 'A',
     scope: {
@@ -175,11 +175,11 @@ angular.module('gavruk.card', [])
         if (oldVal === newVal && !newVal) {
           return;
         }
-        
+
         var evt = document.createEvent('HTMLEvents');
         evt.initEvent('keyup', false, true);
         element[0].dispatchEvent(evt);
       });
     }
   };
-});
+}]);


### PR DESCRIPTION
This error occurs when attempting to invoke a function or provider which has not been explicitly annotated, while the application is running with strict-di mode enabled.

This change adds explicit annotation so we can use strict mode and the application compiles without errors.
