### PR TITLE
Use timeout to allow usage of interpolated bindings

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -8,7 +8,7 @@ var hasRequire = window && window.angular ? false : typeof require === 'function
   .controller('CardCtrl', ['$scope', function ($scope) {
   }])
 
-  .directive('card', ['$compile', function ($compile) {
+  .directive('card', ['$timeout', function ($timeout) {
     return {
       restrict: 'A',
       scope: {
@@ -81,7 +81,11 @@ var hasRequire = window && window.angular ? false : typeof require === 'function
           opts.formSelectors.nameInput = 'input[name="' + cardCtrl.nameInput[0].name + '"]';
         }
 
-        new Card(opts);
+        //Don't initialize card until angular has had a chance to update the DOM with any interpolated bindings
+        $timeout()
+            .then(function () {
+              new Card(opts);
+            });
       }
     };
   }])


### PR DESCRIPTION
I have a need to show more than one card form on a page. Since the card-container binding is required and it wants an element id, having duplicate ids on a page won't work. So, using an id with something like card-container{{$id}} solves the unique issue, but when the Card class is instantiated, angular has not yet completed the interpolation and so Card cannot find the element. Using a timeout solves this issue. 

If there is a better way to solve this, please let me know.