### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ http://jessepollak.github.io/card/
 ### npm
 `npm install angular-card`
 
-##Usage
+## Usage
 
-###`name` is required for form and inputs (you can use any unique name)
-###`width` is optional, it can be set on the element or the options object (defaults to 350)
+### `name` is required for form and inputs (you can use any unique name)
+### `width` is optional, it can be set on the element or the options object (defaults to 350)
 
 ```html
 <form action="#"


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
