### PR TITLE
Moved angularjs to peer and dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "angular-card",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "angular": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.4.14.tgz",
-      "integrity": "sha1-nQ/q9gzm5SzlD0nuMoZW0eGHXDc="
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.6.tgz",
+      "integrity": "sha1-/Vo8+0N844LYVO4BEgeXl4Uny2Q=",
+      "dev": true
     },
     "card": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,12 @@
   },
   "homepage": "https://github.com/gavruk/angular-card#readme",
   "dependencies": {
-    "card": "^2.4.0",
-    "angular": "~1.4.8"
+    "card": "^2.4.0"
+  },
+  "peerDependencies": {
+    "angular": "^1.4.8"
+  },
+  "devDependencies": {
+    "angular": "^1.4.8"
   }
 }


### PR DESCRIPTION
This will help prevent angular from being included more than once in some client build processes.